### PR TITLE
Indexing GitLab repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A collection of self-contained and well-documented issues for newcomers to start
    GITHUB_USERNAME = "<your-username-here>"
    GITHUB_API_KEY = "<your-personal-access-token-here>"
    PAGURE_API_KEY = ""
+   GITLAB_API_KEY = ""
    ```
 7. Run `index-easyfix-issues` being in the same directory to index the Easyfix relevant issues from a variety of Git forges.
 8. Run `start-easyfix-server -p 9696 -4` to start the Easyfix server.

--- a/repolist.yml
+++ b/repolist.yml
@@ -33,162 +33,169 @@ forges:
   pagure:
     url: https://pagure.io/
     repositories:
-        elections:
-          label: easyfix
-          contact: bcotton
-        fedocal:
-          label: easyfix
-          contact: pingou
-        fedora-budget:
-          label: easyfix
-          contact: riecatnor
-        fedora-business-cards:
-          label: easyfix
-          contact: bex
-        fedora-ci/general:
-          label: easyfix
-          contact: bookwar
-        fedora-commops:
-          label: good first issue
-          contact: bt0dotninja
-        fedora-diversity:
-          label: easyfix
-          contact: jonatoni
-        fedora-docs/docs-fp-o:
-          label: easyfix
-          contact: pbokoc
-        fedora-docs/quick-docs:
-          label: good first issue
-          contact: ankursinha
-        fedora-docs/system-administrators:
-          label: easyfix
-          contact: pbokoc
-        fedora-docs/release-notes:
-          label: easyfix
-          contact: pbokoc
-        fedora-docs/install-guide:
-          label: easyfix
-          contact: pbokoc
-        fedora-infrastructure:
-          label: easyfix
-          contact: kevin
-        fedora-join/Fedora-Join:
-          label: easyfix
-          contact: ankursinha
-        fedora-marketing:
-          label: easyfix
-          contact: x3mboy
-        fedora-qa:
-          label: easyfix
-          contact: adamwill
-        fedora-qa/blockerbugs:
-          label: easyfix
-          contact: tflink
-        fedora-qa/check-compose:
-          label: easyfix
-          contact: adamwill
-        fedora-qa/createhdds:
-          label: easyfix
-          contact: adamwill
-        fedora-qa/fedora_openqa:
-          label: easyfix
-          contact: adamwill
-        fedora-qa/openqa_docker:
-          label: easyfix
-          contact: adamwill
-        fedora-qa/os-auotinst-distri-fedora:
-          label: easyfix
-          contact: adamwill
-        fedora-qa/qa-docs:
-          label: easyfix
-          contact: sumantrom
-        fedora-qa/qa-misc:
-          label: easyfix
-          contact: kparal
-        fedora-qa/qa-stats:
-          label: easyfix
-          contact: kparal
-        fedora-qa/relvalconsumer:
-          label: easyfix
-          contact: adamwill
-        fedora-qa/testdays-web:
-          label: easyfix
-          contact: jskladan
-        fedora-qa/uf-monitor:
-          label: easyfix
-          contact: tflink
-        fedora-websites:
-          label: easyfix
-          contact: t0xic0der
-        fedoramagazine-images:
-          label: easyfix
-          contact: ryanlerch
-        freeipa:
-          label: easyfix
-          contact: mkosek
-        ipsilon:
-          label: easyfix
-          contact: puiterwijk
-        mindshare:
-          label: good first issue
-          contact: riecatnor
-        neuro-sig/NeuroFedora:
-          label: good first issue
-          contact: ankursinha
-        neuro-sig/documentation:
-          label: good first issue
-          contact: ankursinha
-        pagure:
-          label: easyfix
-          contact: pingou
-        pungi:
-          label: easy
-          contact: lsedlar
-        releng:
-          label: easyfix
-          contact: mohanboddu
-        SSSD/sssd:
-          label: easyfix
-          contact: jhrozek
-        taskotron/base_images:
-          label: easyfix
-          contact: jskladan
-        taskotron:
-          label: easyfix
-          contact: kparal
-        taskotron/execdb:
-          label: easyfix
-          contact: jskladan
-        taskotron/libtaskotron:
-          label: easyfix
-          contact: kparal
-        taskotron/resultsdb_api:
-          label: easyfix
-          contact: jskladaan
-        taskotron/resultsdb_conventions:
-          label: easyfix
-          contact: adamwill
-        taskotron/resultsdb:
-          label: easyfix
-          contact: jskladan
-        taskotron/taskotron-docker:
-          label: easyfix
-          contact: jskladan
-        taskotron/taskotron-trigger:
-          label: easyfix
-          contact: jskladan
-        taskotron/task-rpmdeplint:
-          label: easyfix
-          contact: kparal
-        taskotron/rpmgrill:
-          label: easyfix
-          contact: kparal
-        taskotron/task-taskotron-ci:
-          label: easyfix
-          contact: jskladan
-        taskotron/vault:
-          label: easyfix
-          contact: jskladan
-        testcloud:
-          label: easyfix
-          contact: lbrabec
+      elections:
+        label: easyfix
+        contact: bcotton
+      fedocal:
+        label: easyfix
+        contact: pingou
+      fedora-budget:
+        label: easyfix
+        contact: riecatnor
+      fedora-business-cards:
+        label: easyfix
+        contact: bex
+      fedora-ci/general:
+        label: easyfix
+        contact: bookwar
+      fedora-commops:
+        label: good first issue
+        contact: bt0dotninja
+      fedora-diversity:
+        label: easyfix
+        contact: jonatoni
+      fedora-docs/docs-fp-o:
+        label: easyfix
+        contact: pbokoc
+      fedora-docs/quick-docs:
+        label: good first issue
+        contact: ankursinha
+      fedora-docs/system-administrators:
+        label: easyfix
+        contact: pbokoc
+      fedora-docs/release-notes:
+        label: easyfix
+        contact: pbokoc
+      fedora-docs/install-guide:
+        label: easyfix
+        contact: pbokoc
+      fedora-infrastructure:
+        label: easyfix
+        contact: kevin
+      fedora-join/Fedora-Join:
+        label: easyfix
+        contact: ankursinha
+      fedora-marketing:
+        label: easyfix
+        contact: x3mboy
+      fedora-qa:
+        label: easyfix
+        contact: adamwill
+      fedora-qa/blockerbugs:
+        label: easyfix
+        contact: tflink
+      fedora-qa/check-compose:
+        label: easyfix
+        contact: adamwill
+      fedora-qa/createhdds:
+        label: easyfix
+        contact: adamwill
+      fedora-qa/fedora_openqa:
+        label: easyfix
+        contact: adamwill
+      fedora-qa/openqa_docker:
+        label: easyfix
+        contact: adamwill
+      fedora-qa/os-auotinst-distri-fedora:
+        label: easyfix
+        contact: adamwill
+      fedora-qa/qa-docs:
+        label: easyfix
+        contact: sumantrom
+      fedora-qa/qa-misc:
+        label: easyfix
+        contact: kparal
+      fedora-qa/qa-stats:
+        label: easyfix
+        contact: kparal
+      fedora-qa/relvalconsumer:
+        label: easyfix
+        contact: adamwill
+      fedora-qa/testdays-web:
+        label: easyfix
+        contact: jskladan
+      fedora-qa/uf-monitor:
+        label: easyfix
+        contact: tflink
+      fedora-websites:
+        label: easyfix
+        contact: t0xic0der
+      fedoramagazine-images:
+        label: easyfix
+        contact: ryanlerch
+      freeipa:
+        label: easyfix
+        contact: mkosek
+      ipsilon:
+        label: easyfix
+        contact: puiterwijk
+      mindshare:
+        label: good first issue
+        contact: riecatnor
+      neuro-sig/NeuroFedora:
+        label: good first issue
+        contact: ankursinha
+      neuro-sig/documentation:
+        label: good first issue
+        contact: ankursinha
+      pagure:
+        label: easyfix
+        contact: pingou
+      pungi:
+        label: easy
+        contact: lsedlar
+      releng:
+        label: easyfix
+        contact: mohanboddu
+      SSSD/sssd:
+        label: easyfix
+        contact: jhrozek
+      taskotron/base_images:
+        label: easyfix
+        contact: jskladan
+      taskotron:
+        label: easyfix
+        contact: kparal
+      taskotron/execdb:
+        label: easyfix
+        contact: jskladan
+      taskotron/libtaskotron:
+        label: easyfix
+        contact: kparal
+      taskotron/resultsdb_api:
+        label: easyfix
+        contact: jskladaan
+      taskotron/resultsdb_conventions:
+        label: easyfix
+        contact: adamwill
+      taskotron/resultsdb:
+        label: easyfix
+        contact: jskladan
+      taskotron/taskotron-docker:
+        label: easyfix
+        contact: jskladan
+      taskotron/taskotron-trigger:
+        label: easyfix
+        contact: jskladan
+      taskotron/task-rpmdeplint:
+        label: easyfix
+        contact: kparal
+      taskotron/rpmgrill:
+        label: easyfix
+        contact: kparal
+      taskotron/task-taskotron-ci:
+        label: easyfix
+        contact: jskladan
+      taskotron/vault:
+        label: easyfix
+        contact: jskladan
+      testcloud:
+        label: easyfix
+        contact: lbrabec
+  gitlab:
+    url: https://gitlab.com/
+    repositories:
+      t0xic0der/fragment:
+        pid: 29571186
+        label: easyfix
+        contact: t0xic0der

--- a/src/fedora_easyfix/utilities/generate.py
+++ b/src/fedora_easyfix/utilities/generate.py
@@ -29,6 +29,7 @@ from fedora_easyfix.__init__ import __version__
 from fedora_easyfix.utilities.compose import StatusDecorator
 from fedora_easyfix.utilities.github import GitHubRepositories
 from fedora_easyfix.utilities.pagure import PagureRepositories
+from fedora_easyfix.utilities.gitlab import GitLabRepositories
 from yaml import CLoader, load
 
 statdcrt = StatusDecorator()
@@ -53,6 +54,7 @@ def mainfunc():
         github_username = envrvars["GITHUB_USERNAME"]
         github_api_key = envrvars["GITHUB_API_KEY"]
         pagure_api_key = envrvars["PAGURE_API_KEY"]
+        gitlab_api_key = envrvars["GITLAB_API_KEY"]
         with open("repolist.yml", "r") as yamlfile:
             yamldict = load(yamlfile.read(), Loader=CLoader)
         if yamldict["repolist_version"] == __version__:
@@ -75,6 +77,15 @@ def mainfunc():
                     pagure_repository_list,
                     pagure_base_url,
                     pagure_api_key
+                ).return_repository_collection()
+            if "gitlab" in yamldict["forges"].keys():
+                gitlab_repository_list = yamldict["forges"]["gitlab"]["repositories"]
+                gitlab_base_url = yamldict["forges"]["gitlab"]["url"]
+                statdcrt.warning("Found %s repositories on GitLab" %len(yamldict["forges"]["gitlab"]["repositories"].keys()))
+                ticket_collection["gitlab"] = GitLabRepositories(
+                    gitlab_repository_list,
+                    gitlab_base_url,
+                    gitlab_api_key
                 ).return_repository_collection()
             ticket_collection["collection_updated_at"] = time()
             write_index_to_local_json(ticket_collection)

--- a/src/fedora_easyfix/utilities/gitlab.py
+++ b/src/fedora_easyfix/utilities/gitlab.py
@@ -1,0 +1,108 @@
+"""
+    Copyright (c) 2021 Fedora Websites and Apps
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+"""
+
+from json import loads
+
+from fedora_easyfix.utilities.compose import StatusDecorator
+from urllib3 import PoolManager
+
+httpobjc = PoolManager()
+api_base_url = "https://gitlab.com/api/v4/projects/"
+statdcrt = StatusDecorator()
+
+
+class GitLabRepositories():
+    def __init__(self, repository_list, base_url, api_key):
+        self.repository_list = repository_list
+        self.base_url = base_url
+        self.api_key = api_key
+        self.repository_collection = {}
+
+    def fetch_tickets_from_repository(self, repository_name):
+        label = self.repository_list[repository_name]["label"]
+        project_id = self.repository_list[repository_name]["pid"]
+        contact = self.repository_list[repository_name]["contact"]
+        api_issue_endpoint = "%s%s/issues" % (api_base_url, project_id)
+        respobjc = httpobjc.request(
+            "GET",
+            api_issue_endpoint,
+            fields={
+                "per_page": 100,
+                "labels": label,
+                "state": "opened"
+            }
+        )
+        respdict = loads(respobjc.data)
+        ticket_count = 0
+        ticket_list = {}
+        for ticket in respdict:
+            ticket_count += 1
+            ticket_list[ticket["iid"]] = {
+                "title": ticket["title"],
+                "date_created": ticket["created_at"],
+                "last_updated": ticket["updated_at"],
+                "creator": {
+                    "full_url": ticket["author"]["web_url"],
+                    "fullname": ticket["author"]["name"],
+                    "name": ticket["author"]["username"]
+                },
+                "url": ticket["web_url"],
+                "labels": ticket["labels"]
+            }
+        api_project_endpoint = "%s%s" % (api_base_url, project_id)
+        respobjc = httpobjc.request(
+            "GET",
+            api_project_endpoint,
+        )
+        respdict = loads(respobjc.data)
+        ticket_dict = {
+            "ticket_count": ticket_count,
+            "ticket_list": ticket_list,
+            "contact": "%s@fedoraproject.org" % contact,
+            "url": respdict["web_url"],
+            "description": respdict["description"],
+            "id": respdict["id"],
+            "target_label": label,
+            "maintainer": {
+                "full_url": respdict["namespace"]["web_url"],
+                "fullname": respdict["namespace"]["name"],
+                "name": respdict["namespace"]["path"]
+            },
+            "tags": respdict["tag_list"],
+            "date_created": respdict["created_at"]
+        }
+        return ticket_dict, ticket_count
+
+    def return_repository_collection(self):
+        repositories_passed, repositories_failed, repositories_total = 0, 0, 0
+        for repository_name in self.repository_list.keys():
+            repositories_total += 1
+            try:
+                self.repository_collection[repository_name], ticket_count = self.fetch_tickets_from_repository(repository_name)
+                statdcrt.general("[PASS] %s - Retrieved %s tickets" % (repository_name, ticket_count))
+                repositories_passed += 1
+            except Exception as expt:
+                statdcrt.general("[FAIL] %s - Failed to retrieve tickets" % repository_name)
+                repositories_failed += 1
+                continue
+        statdcrt.success("%s passed, %s failed, %s total" %(repositories_passed, repositories_failed, repositories_total))
+        return self.repository_collection


### PR DESCRIPTION
Fixes #10 

Obligatory execution log

```
[ ★ ] Indexing tickets...
[ ! ] Found 9 repositories on GitHub
      [PASS] avocado-framework/avocado - Retrieved 10 tickets
      [PASS] cockpit-project/cockpit - Retrieved 0 tickets
      [PASS] fedora-infra/bodhi - Retrieved 2 tickets
      [PASS] fedora-infra/datagrepper - Retrieved 0 tickets
      [PASS] fedora-infra/datanommer - Retrieved 0 tickets
      [PASS] fedora-infra/nuancier - Retrieved 0 tickets
      [PASS] release-monitoring/anitya - Retrieved 1 tickets
      [PASS] RITlug/teleirc - Retrieved 2 tickets
      [PASS] RITlug/TigerOS - Retrieved 1 tickets
[ ✓ ] 9 passed, 0 failed, 9 total
[ ! ] Found 53 repositories on Pagure
      [PASS] elections - Retrieved 0 tickets
      [PASS] fedocal - Retrieved 1 tickets
      [PASS] fedora-budget - Retrieved 0 tickets
      [PASS] fedora-business-cards - Retrieved 2 tickets
      [PASS] fedora-ci/general - Retrieved 0 tickets
      [PASS] fedora-commops - Retrieved 2 tickets
      [PASS] fedora-diversity - Retrieved 0 tickets
      [PASS] fedora-docs/docs-fp-o - Retrieved 2 tickets
      [PASS] fedora-docs/quick-docs - Retrieved 11 tickets
      [FAIL] fedora-docs/system-administrators - Failed to retrieve tickets
      [PASS] fedora-docs/release-notes - Retrieved 0 tickets
      [PASS] fedora-docs/install-guide - Retrieved 1 tickets
      [PASS] fedora-infrastructure - Retrieved 1 tickets
      [PASS] fedora-join/Fedora-Join - Retrieved 4 tickets
      [PASS] fedora-marketing - Retrieved 0 tickets
      [PASS] fedora-qa - Retrieved 1 tickets
      [PASS] fedora-qa/blockerbugs - Retrieved 1 tickets
      [PASS] fedora-qa/check-compose - Retrieved 0 tickets
      [PASS] fedora-qa/createhdds - Retrieved 0 tickets
      [PASS] fedora-qa/fedora_openqa - Retrieved 0 tickets
      [PASS] fedora-qa/openqa_docker - Retrieved 0 tickets
      [FAIL] fedora-qa/os-auotinst-distri-fedora - Failed to retrieve tickets
      [PASS] fedora-qa/qa-docs - Retrieved 0 tickets
      [PASS] fedora-qa/qa-misc - Retrieved 0 tickets
      [PASS] fedora-qa/qa-stats - Retrieved 0 tickets
      [PASS] fedora-qa/relvalconsumer - Retrieved 0 tickets
      [PASS] fedora-qa/testdays-web - Retrieved 1 tickets
      [PASS] fedora-qa/uf-monitor - Retrieved 0 tickets
      [PASS] fedora-websites - Retrieved 1 tickets
      [PASS] fedoramagazine-images - Retrieved 0 tickets
      [PASS] freeipa - Retrieved 6 tickets
      [PASS] ipsilon - Retrieved 3 tickets
      [PASS] mindshare - Retrieved 0 tickets
      [PASS] neuro-sig/NeuroFedora - Retrieved 19 tickets
      [PASS] neuro-sig/documentation - Retrieved 0 tickets
      [PASS] pagure - Retrieved 23 tickets
      [PASS] pungi - Retrieved 0 tickets
      [PASS] releng - Retrieved 0 tickets
      [PASS] SSSD/sssd - Retrieved 0 tickets
      [PASS] taskotron/base_images - Retrieved 0 tickets
      [PASS] taskotron - Retrieved 0 tickets
      [PASS] taskotron/execdb - Retrieved 0 tickets
      [PASS] taskotron/libtaskotron - Retrieved 4 tickets
      [PASS] taskotron/resultsdb_api - Retrieved 0 tickets
      [PASS] taskotron/resultsdb_conventions - Retrieved 0 tickets
      [PASS] taskotron/resultsdb - Retrieved 0 tickets
      [PASS] taskotron/taskotron-docker - Retrieved 0 tickets
      [PASS] taskotron/taskotron-trigger - Retrieved 0 tickets
      [PASS] taskotron/task-rpmdeplint - Retrieved 0 tickets
      [FAIL] taskotron/rpmgrill - Failed to retrieve tickets
      [PASS] taskotron/task-taskotron-ci - Retrieved 0 tickets
      [PASS] taskotron/vault - Retrieved 0 tickets
      [PASS] testcloud - Retrieved 0 tickets
[ ✓ ] 50 passed, 3 failed, 53 total
[ ! ] Found 1 repositories on GitLab
      [PASS] t0xic0der/fragment - Retrieved 3 tickets
[ ✓ ] 1 passed, 0 failed, 1 total
[ ★ ] Indexing complete!
```